### PR TITLE
Add error if people try to send chat commands

### DIFF
--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
@@ -14,18 +15,25 @@ namespace W3ChampionsChatService.Tests
     {
         private ChatHub _chatHub;
         private IChatAuthenticationService _chatAuthenticationService;
-        private Mock<MuteRepository> _muteRepository;
+        private MuteRepository _muteRepository;
         private Mock<IHubCallerClients> _clients;
         private Mock<HubCallerContext> _hubCallerContext;
         private ConnectionMapping _connectionMapping;
         private ChatHistory _chatHistory;
         private SettingsRepository _settingsRepository;
         private string _jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJiYXR0bGVUYWciOiJtb2Rtb3RvIzI4MDkiLCJpc0FkbWluIjoiVHJ1ZSIsIm5hbWUiOiJtb2Rtb3RvIn0.0rJooIabRqj_Gt0fuuW5VP6ICdV1FJfwRJYuhesou7rPqE9HWZRewm12bd4iWusa4lcYK6vp5LCr6fBj4XUc2iQ4Bo9q3qtu54Rwc-eH2m-_7VqJE6D3yLm7Gcre0NE2LHZjh7qA5zHQn5kU_ugOmcovaVJN_zVEM1wRrVwR6mkNDwIwv3f_A_3AQOB8s0rin0MS4950DnFkmM0CLQ-MMzwFHg_kKgiStSiAp-2Mlu5SijGUx8keM3ArjOj7Kplk_wxjPCkjplIfAHb5qXBpdcO5exXD7UJwETqUHu4NgH-9-GWzPPNCW5BMfzPV-BMiO1sESEb4JZUZqTSJCnAG2d1mx_yukDHR_8ZSd-rB5en2WzOdN1Fjds_M0u5BvnAaLQOzz69YURL4mnI-jiNpFNokRWYjzG-_qEVJTRtUugiCipT6SMs3SlwWujxXsNSZZU0LguOuAh4EqF9ST7m_ttOcZvg5G1RLOy6A1QzWVG06Byw-7dZvMpoHrMSqjlNcJk7XtDamAVDyUNpjrqlu_I17U5DN6f8evfBtngsSgpjeswy6ccul10HRNO210I7VejGOmEsxnIDWyF-5p-UIuOaTgMiXhElwSpkIaLGQJXHFXc859UjvqC7jSRnPWpRlYRo7UpKmCJ59fgK-SzZlbp27gN_1uhk18eEWrenn6ew";
+        
+        // For capturing messages in tests
+        private ChatMessage _capturedCallerMessage;
+        private ChatMessage _capturedGroupMessage;
+        private bool _groupMessageSent;
+        private Mock<IClientProxy> _callerProxy;
+        private Mock<IClientProxy> _groupProxy;
 
         [SetUp]
         public void SetupBeforeEach()
         {
-            _muteRepository = new Mock<MuteRepository>(MongoClient);
+            _muteRepository = new MuteRepository(MongoClient);
             _clients = new Mock<IHubCallerClients>();
             _hubCallerContext = new Mock<HubCallerContext>();
             ResetSetups();
@@ -40,20 +48,70 @@ namespace W3ChampionsChatService.Tests
             
             _chatHub = new ChatHub(
                 _chatAuthenticationService, 
-                _muteRepository.Object, 
+                _muteRepository, 
                 _settingsRepository,
                 _connectionMapping, 
                 _chatHistory, 
                 null, 
                 null);
 
-            _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(new Mock<IClientProxy>().Object);
-            _clients.Setup(c => c.Caller).Returns(new Mock<IClientProxy>().Object);
+            // Setup message capturing proxies
+            _capturedCallerMessage = null;
+            _capturedGroupMessage = null;
+            _groupMessageSent = false;
+            
+            _callerProxy = new Mock<IClientProxy>();
+            _callerProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                .Callback<string, object[], CancellationToken>((method, args, token) => 
+                {
+                    if (method == "ReceiveMessage" && args.Length > 0 && args[0] is ChatMessage msg)
+                    {
+                        _capturedCallerMessage = msg;
+                    }
+                })
+                .Returns(Task.CompletedTask);
+                
+            _groupProxy = new Mock<IClientProxy>();
+            _groupProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                .Callback<string, object[], CancellationToken>((method, args, token) => 
+                {
+                    if (method == "ReceiveMessage")
+                    {
+                        _groupMessageSent = true;
+                        if (args.Length > 0 && args[0] is ChatMessage msg)
+                        {
+                            _capturedGroupMessage = msg;
+                        }
+                    }
+                })
+                .Returns(Task.CompletedTask);
+            
+            _clients.Setup(c => c.Caller).Returns(_callerProxy.Object);
+            _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
             _chatHub.Clients = _clients.Object;
 
             _hubCallerContext.Setup(c => c.ConnectionId).Returns("TestId");
             _chatHub.Context = _hubCallerContext.Object;
             _chatHub.Groups = new Mock<IGroupManager>().Object;
+        }
+
+        // Helper method to authenticate a user and prepare for tests
+        private async Task LoginUser()
+        {
+            await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "[123]", new ProfilePicture()));
+        }
+
+        // Helper method to verify message was sent only to caller and not to group
+        private void VerifyMessageOnlySentToCaller(string expectedMessage, string expectedSenderName = "[SYSTEM]")
+        {
+            // Verify message sent to caller
+            Assert.IsNotNull(_capturedCallerMessage, "No message was sent to caller");
+            Assert.AreEqual(expectedMessage, _capturedCallerMessage.Message);
+            Assert.AreEqual(expectedSenderName, _capturedCallerMessage.User.Name);
+            
+            // Verify no message broadcast to group
+            Assert.IsFalse(_groupMessageSent, "Message was incorrectly sent to group");
+            Assert.AreEqual(0, _chatHistory.GetMessages("W3C Lounge").Count, "Message was incorrectly added to history");
         }
 
         [Test]
@@ -94,9 +152,74 @@ namespace W3ChampionsChatService.Tests
             Assert.AreEqual("modmoto#2809", userByToken1.BattleTag);
         }
 
+        [Test]
+        public async Task BannedUser_CannotSendMessage()
+        {
+            // Login before ban
+            await LoginUser();
+
+            // Reset the group message flag after login
+            _groupMessageSent = false;
+
+            // Setup muted player
+            var mute = new LoungeMuteRequest
+            {
+                battleTag = "peter#123",
+                endDate = DateTime.UtcNow.AddDays(1).ToString(),
+                author = "modmoto#2809"
+            };
+
+            await _muteRepository.AddLoungeMute(mute);
+            
+            // Set up tracking for Context.Abort()
+            bool abortCalled = false;
+            _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+            
+            // Send message
+            await _chatHub.SendMessage("Hello world");
+            
+            // Verify connection aborted and message not sent
+            Assert.IsTrue(abortCalled);
+            Assert.IsFalse(_groupMessageSent, "No message should be sent to the group for banned users");
+            Assert.AreEqual(0, _chatHistory.GetMessages("W3C Lounge").Count);
+        }
+        
+        [Test]
+        public async Task RegularMessage_IsBroadcastToAllUsers()
+        {
+            // Login user and send message
+            await LoginUser();
+            await _chatHub.SendMessage("Hello world");
+            
+            // Verify message is in history
+            var messages = _chatHistory.GetMessages("W3C Lounge");
+            Assert.AreEqual(1, messages.Count);
+            Assert.AreEqual("Hello world", messages[0].Message);
+            
+            // Verify message is broadcast to group
+            Assert.IsNotNull(_capturedGroupMessage);
+            Assert.AreEqual("Hello world", _capturedGroupMessage.Message);
+            Assert.AreEqual("peter#123", _capturedGroupMessage.User.BattleTag);
+        }
+        
+        [Test]
+        [TestCase("/w john#456 Hello there", "Private messages to other players are currently not supported!", Description = "Short whisper command")]
+        [TestCase("/whisper john#456 Hello there", "Private messages to other players are currently not supported!", Description = "Full whisper command")]
+        [TestCase("/r Hello there again", "Private messages to other players are currently not supported!", Description = "Reply command")]
+        [TestCase("/help", "Chat commands are currently not supported!", Description = "Other command")]
+        public async Task ChatCommands_Not_Supported(string command, string expectedResponse)
+        {
+            await LoginUser();
+            
+            // Test the command
+            await _chatHub.SendMessage(command);
+            
+            // Verify system message sent only to caller
+            VerifyMessageOnlySentToCaller(expectedResponse);
+        }
+
         private void ResetSetups()
         {
-            _muteRepository.Reset();
             _clients.Reset();
             _hubCallerContext.Reset();
         }

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -205,7 +205,8 @@ namespace W3ChampionsChatService.Tests
         [Test]
         [TestCase("/w john#456 Hello there", "Private messages to other players are currently not supported!", Description = "Short whisper command")]
         [TestCase("/whisper john#456 Hello there", "Private messages to other players are currently not supported!", Description = "Full whisper command")]
-        [TestCase("/r Hello there again", "Private messages to other players are currently not supported!", Description = "Reply command")]
+        [TestCase("/r Hello there again", "Private messages to other players are currently not supported!", Description = "Short reply command")]
+        [TestCase("/reply Hello there again", "Private messages to other players are currently not supported!", Description = "Full reply command")]
         [TestCase("/help", "Chat commands are currently not supported!", Description = "Other command")]
         public async Task ChatCommands_Not_Supported(string command, string expectedResponse)
         {

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -52,10 +52,42 @@ namespace W3ChampionsChatService.Chats
                     Context.Abort();
                 } else {
                     var chatMessage = new ChatMessage(user, trimmedMessage);
-                    _chatHistory.AddMessage(chatRoom, chatMessage);
-                    await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
+                    if (!await processChatCommand(chatMessage))
+                    {
+                        _chatHistory.AddMessage(chatRoom, chatMessage);
+                        await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        /// Processes chat commands and returns a boolean indicating whether a command was processed 
+        /// or the message should be sent as a normal message.
+        /// </summary>
+        /// <param name="message">The chat message to process.</param>
+        /// <returns>True if a command was processed, false otherwise.</returns>
+        private async Task<bool> processChatCommand(ChatMessage message)
+        {
+            if (!message.Message.StartsWith("/"))
+            {
+                return false;
+            }
+            
+            var fakeSystemUser = message.User.GenerateFakeSystemUser();
+            string messageToSend;
+
+            if (message.Message.StartsWith("/w") || message.Message.StartsWith("/whisper") || message.Message.StartsWith("/r"))
+            {
+                messageToSend = "Private messages to other players are currently not supported!";
+            }
+            else
+            {
+                messageToSend = "Chat commands are currently not supported!";
+            }
+
+            await Clients.Caller.SendAsync("ReceiveMessage", new ChatMessage(fakeSystemUser, messageToSend));
+            return true;
         }
 
         public override async Task OnConnectedAsync()

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -52,7 +52,7 @@ namespace W3ChampionsChatService.Chats
                     Context.Abort();
                 } else {
                     var chatMessage = new ChatMessage(user, trimmedMessage);
-                    if (!await processChatCommand(chatMessage))
+                    if (!await ProcessChatCommand(chatMessage))
                     {
                         _chatHistory.AddMessage(chatRoom, chatMessage);
                         await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
@@ -67,7 +67,7 @@ namespace W3ChampionsChatService.Chats
         /// </summary>
         /// <param name="message">The chat message to process.</param>
         /// <returns>True if a command was processed, false otherwise.</returns>
-        private async Task<bool> processChatCommand(ChatMessage message)
+        private async Task<bool> ProcessChatCommand(ChatMessage message)
         {
             if (!message.Message.StartsWith("/"))
             {
@@ -77,7 +77,7 @@ namespace W3ChampionsChatService.Chats
             var fakeSystemUser = message.User.GenerateFakeSystemUser();
             string messageToSend;
 
-            if (message.Message.StartsWith("/w") || message.Message.StartsWith("/whisper") || message.Message.StartsWith("/r"))
+            if (message.Message.StartsWith("/w ") || message.Message.StartsWith("/whisper ") || message.Message.StartsWith("/r ")  || message.Message.StartsWith("/reply "))
             {
                 messageToSend = "Private messages to other players are currently not supported!";
             }

--- a/W3ChampionsChatService/Chats/ChatUser.cs
+++ b/W3ChampionsChatService/Chats/ChatUser.cs
@@ -19,6 +19,23 @@ namespace W3ChampionsChatService.Chats
         public string Name { get; set; }
         public string ClanTag { get; set; }
         public ProfilePicture ProfilePicture { get; set; }
+
+        /// <summary>
+        /// Generates a fake user with the name "SYSTEM" that is based on this user.
+        /// This approach is necessary in order to ensure that we do not break backwards compatibility
+        /// with the old launcher. This way, a user can click on the "SYSTEM" user and won't get a 404
+        /// because the Battle Tag has not been found.
+        /// </summary>
+        /// <returns>A ChatUser object representing the derived fake system user.</returns>
+        public ChatUser GenerateFakeSystemUser()
+        {
+            var systemUser = new ChatUser(this.BattleTag, this.IsAdmin, this.ClanTag, this.ProfilePicture);
+            // Manually set the name to "SYSTEM" because the constructor does not set it.
+            // This will allow BattleTag to be the same as the original user to allow clicking it while
+            // showing [SYSTEM] as the name in the chat.
+            systemUser.Name = "[SYSTEM]";
+            return systemUser;
+        }
     }
 
     public class ProfilePicture


### PR DESCRIPTION
We regularly have people trying to use chat commands and to whisper. This PR adds proper error message in a backwards compatible way.

<img width="446" alt="image" src="https://github.com/user-attachments/assets/70f7e584-4b2e-4c5c-98b1-a0126c464fc1" />
