### PR TITLE
Add Serilog logging

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+dotnet-core 8.0.408

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,5 +11,8 @@
     <PackageVersion Include="nunit" Version="3.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/W3ChampionsChatService/Chats/ChatAuthenticationService.cs
+++ b/W3ChampionsChatService/Chats/ChatAuthenticationService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using MongoDB.Driver;
 using W3ChampionsChatService.Authentication;
+using Serilog;
 
 namespace W3ChampionsChatService.Chats;
 
@@ -28,8 +29,9 @@ public class ChatAuthenticationService(
             var userDetails = await _websiteBackendRepository.GetChatDetails(user.BattleTag);
             return new ChatUser(user.BattleTag, user.IsAdmin, userDetails?.ClanId, userDetails?.ProfilePicture);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.Error(ex, "Error getting user by token");
             return null;
         }
     }

--- a/W3ChampionsChatService/Mutes/MuteController.cs
+++ b/W3ChampionsChatService/Mutes/MuteController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsChatService.Authentication;
+using Serilog;
 
 namespace W3ChampionsChatService.Mutes;
 
@@ -41,6 +42,7 @@ public class MuteController(MuteRepository muteRepository) : ControllerBase
             return BadRequest("Ban End Date must be set.");
         }
 
+        Log.Information("Adding lounge mute for {BattleTag} until {EndDate} by {Author}", loungeMuteRequest.battleTag, loungeMuteRequest.endDate, loungeMuteRequest.author);
         await _muteRepository.AddLoungeMute(loungeMuteRequest);
         return Ok();
     }
@@ -53,6 +55,7 @@ public class MuteController(MuteRepository muteRepository) : ControllerBase
         {
             return StatusCode(403);
         }
+        Log.Information("Deleting lounge mute for {BattleTag}", bTag);
         await _muteRepository.DeleteLoungeMute(bTag);
         return Ok();
     }

--- a/W3ChampionsChatService/Program.cs
+++ b/W3ChampionsChatService/Program.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Json;
 
 namespace W3ChampionsChatService;
 
@@ -7,10 +10,20 @@ public class Program
 {
     public static void Main(string[] args)
     {
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+            .MinimumLevel.Override("System.Net.Http.HttpClient", LogEventLevel.Warning) // Filter out verbose HTTP client logs
+            .MinimumLevel.Override("System.Net.Http", LogEventLevel.Warning) // Filter out verbose System.Net.Http logs
+            .WriteTo.Console(new JsonFormatter(), restrictedToMinimumLevel: LogEventLevel.Information) // Write to Console to allow log scraping
+            .CreateLogger();
+        Log.Information("Starting Chat Service");
         CreateHostBuilder(args).Build().Run();
     }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
+            .UseSerilog() // Tell the AspNetCore host to use Serilog for all logging
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -1,4 +1,6 @@
 using System;
+using Serilog;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +16,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        Log.Information("Adding services");
         services.AddControllers();
 
         var mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://157.90.1.251:3513";
@@ -32,10 +35,12 @@ public class Startup
 
         services.AddSingleton<ConnectionMapping>();
         services.AddSingleton<ChatHistory>();
+        Log.Information("Services added");
     }
 
     public void Configure(IApplicationBuilder app)
     {
+        Log.Information("Configuring service");
         // without that, nginx forwarding in docker wont work
         app.UseForwardedHeaders(new ForwardedHeadersOptions
         {
@@ -54,5 +59,6 @@ public class Startup
             endpoints.MapControllers();
             endpoints.MapHub<ChatHub>("/chatHub");
         });
+        Log.Information("Chat Service started");
     }
 }

--- a/W3ChampionsChatService/W3ChampionsChatService.csproj
+++ b/W3ChampionsChatService/W3ChampionsChatService.csproj
@@ -4,6 +4,9 @@
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
         <PackageReference Include="MongoDB.Driver" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently, we are only having logs from AspNetCore to stdout. Those are entirely verbose request-level logs though.

Adds Serilog in the same way as we have it in website-backend.